### PR TITLE
Update inlining macro to compile on newer g++

### DIFF
--- a/src/MurmurHash3.c
+++ b/src/MurmurHash3.c
@@ -30,7 +30,7 @@
 
 #else	// defined(_MSC_VER)
 
-#define	FORCE_INLINE __attribute__((always_inline))
+#define	FORCE_INLINE __attribute__((always_inline)) inline
 
 static inline uint32_t rotl32 ( uint32_t x, int8_t r )
 {


### PR DESCRIPTION
I'm on Debian testing, with gcc version 4.7.3 (Debian 4.7.3-4) and this makes it happy.
