### PR TITLE
Add zstd support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: c
 
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install -qq libsnappy-dev
+ - sudo apt-get install -qq libsnappy-dev libzstd-dev
 
 script: autoreconf --install && ./configure && make && make check

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,9 @@ AM_CONDITIONAL([HAVE_DOXYGEN],
 AC_SEARCH_LIBS([snappy_compress],
   [snappy],,[AC_MSG_ERROR([Could not find snappy])
 ])
+AC_SEARCH_LIBS([ZSTD_compress],
+  [zstd],,[AC_MSG_ERROR([Could not find zstd])
+])
 
 AM_CONDITIONAL([NOT_APPLE], [test x$build_vendor != xapple])
 AM_COND_IF([NOT_APPLE], [

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,7 +6,7 @@ MurmurHash3.h buf.c hashalgorithms.c hashiter.c hashwriter.c \
 logreader.c returncodes.c util.c buf.h hashalgorithms.h hashiter.h \
 sparkey.h util.h endiantools.c \
 hashheader.c hashreader.c logheader.c logwriter.c MurmurHash3.c \
-sparkey-internal.h
+sparkey-internal.h compress.c
 
 pkginclude_HEADERS = sparkey.h
 

--- a/src/bench.c
+++ b/src/bench.c
@@ -217,8 +217,12 @@ static void sparkey_create_uncompressed(int n) {
   sparkey_create(n, SPARKEY_COMPRESSION_NONE, 0);
 }
 
-static void sparkey_create_compressed(int n) {
-  sparkey_create(n, SPARKEY_COMPRESSION_SNAPPY, 1024);
+static void sparkey_create_snappy(int n) {
+  sparkey_create(n, SPARKEY_COMPRESSION_SNAPPY, 4 * 1024);
+}
+
+static void sparkey_create_zstd(int n) {
+  sparkey_create(n, SPARKEY_COMPRESSION_ZSTD, 16 * 1024);
 }
 
 static const char* sparkey_list[] = {"test.spi", "test.spl", NULL};
@@ -231,8 +235,12 @@ static candidate sparkey_candidate_uncompressed = {
   "Sparkey uncompressed", &sparkey_create_uncompressed, &sparkey_randomaccess, &sparkey_files
 };
 
-static candidate sparkey_candidate_compressed = {
-  "Sparkey compressed(1024)", &sparkey_create_compressed, &sparkey_randomaccess, &sparkey_files
+static candidate sparkey_candidate_snappy = {
+  "Sparkey snappy(4K)", &sparkey_create_snappy, &sparkey_randomaccess, &sparkey_files
+};
+
+static candidate sparkey_candidate_zstd = {
+  "Sparkey zstd(16K)", &sparkey_create_zstd, &sparkey_randomaccess, &sparkey_files
 };
 
 /* main */
@@ -273,10 +281,15 @@ int main() {
   test(&sparkey_candidate_uncompressed, 10*1000*1000, 1*1000*1000);
   test(&sparkey_candidate_uncompressed, 100*1000*1000, 1*1000*1000);
 
-  test(&sparkey_candidate_compressed, 1000, 1*1000*1000);
-  test(&sparkey_candidate_compressed, 1000*1000, 1*1000*1000);
-  test(&sparkey_candidate_compressed, 10*1000*1000, 1*1000*1000);
-  test(&sparkey_candidate_compressed, 100*1000*1000, 1*1000*1000);
+  test(&sparkey_candidate_snappy, 1000, 1*1000*1000);
+  test(&sparkey_candidate_snappy, 1000*1000, 1*1000*1000);
+  test(&sparkey_candidate_snappy, 10*1000*1000, 1*1000*1000);
+  test(&sparkey_candidate_snappy, 100*1000*1000, 1*1000*1000);
+
+  test(&sparkey_candidate_zstd, 1000, 1*1000*1000);
+  test(&sparkey_candidate_zstd, 1000*1000, 1*1000*1000);
+  test(&sparkey_candidate_zstd, 10*1000*1000, 1*1000*1000);
+  test(&sparkey_candidate_zstd, 100*1000*1000, 1*1000*1000);
 
   return 0;
 }

--- a/src/bench.c
+++ b/src/bench.c
@@ -222,7 +222,7 @@ static void sparkey_create_snappy(int n) {
 }
 
 static void sparkey_create_zstd(int n) {
-  sparkey_create(n, SPARKEY_COMPRESSION_ZSTD, 16 * 1024);
+  sparkey_create(n, SPARKEY_COMPRESSION_ZSTD, 4 * 1024);
 }
 
 static const char* sparkey_list[] = {"test.spi", "test.spl", NULL};
@@ -240,7 +240,7 @@ static candidate sparkey_candidate_snappy = {
 };
 
 static candidate sparkey_candidate_zstd = {
-  "Sparkey zstd(16K)", &sparkey_create_zstd, &sparkey_randomaccess, &sparkey_files
+  "Sparkey zstd(4K)", &sparkey_create_zstd, &sparkey_randomaccess, &sparkey_files
 };
 
 /* main */

--- a/src/compress.c
+++ b/src/compress.c
@@ -1,0 +1,65 @@
+/*
+* Copyright (c) 2012-2013 Spotify AB
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
+*/
+
+#include "sparkey-internal.h"
+#include "sparkey.h"
+
+#include <snappy-c.h>
+
+
+uint32_t sparkey_snappy_max_compressed_size(uint32_t block_size) {
+  return snappy_max_compressed_length(block_size);
+}
+
+sparkey_returncode sparkey_snappy_decompress(uint8_t *input, uint32_t compressed_size, uint8_t *output, uint32_t *uncompressed_size) {
+  size_t rsize = *uncompressed_size;
+  snappy_status status = snappy_uncompress((char *) input, compressed_size, (char *) output, &rsize);
+  *uncompressed_size = rsize;
+  if (status == SNAPPY_OK) {
+    return SPARKEY_SUCCESS;
+  }
+  return SPARKEY_INTERNAL_ERROR;
+}
+
+sparkey_returncode sparkey_snappy_compress(uint8_t *input, uint32_t uncompressed_size, uint8_t *output, uint32_t *compressed_size) {
+  size_t rsize = *compressed_size;
+  snappy_status status = snappy_compress((char *) input, uncompressed_size, (char *) output, &rsize);
+  *compressed_size = rsize;
+  if (status == SNAPPY_OK) {
+    return SPARKEY_SUCCESS;
+  }
+  return SPARKEY_INTERNAL_ERROR;
+}
+
+struct sparkey_compressor sparkey_compressors[] = {
+  {
+    .max_compressed_size = NULL,
+  },
+  {
+    .max_compressed_size = sparkey_snappy_max_compressed_size,
+    .decompress = sparkey_snappy_decompress,
+    .compress = sparkey_snappy_compress,
+  },
+  {
+    .max_compressed_size = NULL,
+    .decompress = NULL,
+    .compress = NULL,
+  },
+};
+
+void fixme_unused_variable() {
+  (void)sparkey_compressors;
+}

--- a/src/compress.c
+++ b/src/compress.c
@@ -21,11 +21,11 @@
 #include <zstd.h>
 
 
-uint32_t sparkey_snappy_max_compressed_size(uint32_t block_size) {
+static uint32_t sparkey_snappy_max_compressed_size(uint32_t block_size) {
   return snappy_max_compressed_length(block_size);
 }
 
-sparkey_returncode sparkey_snappy_decompress(uint8_t *input, uint32_t compressed_size, uint8_t *output, uint32_t *uncompressed_size) {
+static sparkey_returncode sparkey_snappy_decompress(uint8_t *input, uint32_t compressed_size, uint8_t *output, uint32_t *uncompressed_size) {
   size_t rsize = *uncompressed_size;
   snappy_status status = snappy_uncompress((char *) input, compressed_size, (char *) output, &rsize);
   *uncompressed_size = rsize;
@@ -35,7 +35,7 @@ sparkey_returncode sparkey_snappy_decompress(uint8_t *input, uint32_t compressed
   return SPARKEY_INTERNAL_ERROR;
 }
 
-sparkey_returncode sparkey_snappy_compress(uint8_t *input, uint32_t uncompressed_size, uint8_t *output, uint32_t *compressed_size) {
+static sparkey_returncode sparkey_snappy_compress(uint8_t *input, uint32_t uncompressed_size, uint8_t *output, uint32_t *compressed_size) {
   size_t rsize = *compressed_size;
   snappy_status status = snappy_compress((char *) input, uncompressed_size, (char *) output, &rsize);
   *compressed_size = rsize;
@@ -45,11 +45,11 @@ sparkey_returncode sparkey_snappy_compress(uint8_t *input, uint32_t uncompressed
   return SPARKEY_INTERNAL_ERROR;
 }
 
-uint32_t sparkey_zstd_max_compressed_size(uint32_t block_size) {
+static uint32_t sparkey_zstd_max_compressed_size(uint32_t block_size) {
   return ZSTD_compressBound(block_size);
 }
 
-sparkey_returncode sparkey_zstd_decompress(uint8_t *input, uint32_t compressed_size, uint8_t *output, uint32_t *uncompressed_size) {
+static sparkey_returncode sparkey_zstd_decompress(uint8_t *input, uint32_t compressed_size, uint8_t *output, uint32_t *uncompressed_size) {
   size_t ret = ZSTD_decompress(output, *uncompressed_size, input, compressed_size);
   if (ZSTD_isError(ret)) {
     return SPARKEY_INTERNAL_ERROR;
@@ -58,7 +58,7 @@ sparkey_returncode sparkey_zstd_decompress(uint8_t *input, uint32_t compressed_s
   return SPARKEY_SUCCESS;
 }
 
-sparkey_returncode sparkey_zstd_compress(uint8_t *input, uint32_t uncompressed_size, uint8_t *output, uint32_t *compressed_size) {
+static sparkey_returncode sparkey_zstd_compress(uint8_t *input, uint32_t uncompressed_size, uint8_t *output, uint32_t *compressed_size) {
   size_t ret = ZSTD_compress(output, *compressed_size, input, uncompressed_size, ZSTD_CLEVEL_DEFAULT);
   if (ZSTD_isError(ret)) {
     return SPARKEY_INTERNAL_ERROR;

--- a/src/compress.c
+++ b/src/compress.c
@@ -59,7 +59,7 @@ static sparkey_returncode sparkey_zstd_decompress(uint8_t *input, uint32_t compr
 }
 
 static sparkey_returncode sparkey_zstd_compress(uint8_t *input, uint32_t uncompressed_size, uint8_t *output, uint32_t *compressed_size) {
-  size_t ret = ZSTD_compress(output, *compressed_size, input, uncompressed_size, ZSTD_CLEVEL_DEFAULT);
+  size_t ret = ZSTD_compress(output, *compressed_size, input, uncompressed_size, 3);
   if (ZSTD_isError(ret)) {
     return SPARKEY_INTERNAL_ERROR;
   }

--- a/src/compress.c
+++ b/src/compress.c
@@ -60,6 +60,12 @@ struct sparkey_compressor sparkey_compressors[] = {
   },
 };
 
-void fixme_unused_variable() {
-  (void)sparkey_compressors;
+int sparkey_uses_compressor(sparkey_compression_type t) {
+  switch (t) {
+    case SPARKEY_COMPRESSION_SNAPPY:
+    case SPARKEY_COMPRESSION_ZSTD:
+      return 1;
+    default:
+      return 0;
+  }
 }

--- a/src/logheader.c
+++ b/src/logheader.c
@@ -22,7 +22,7 @@
 #include "endiantools.h"
 #include "util.h"
 
-static char * compression_types[] = { "Uncompressed", "Snappy", NULL };
+static char * compression_types[] = { "Uncompressed", "Snappy", "Zstd", NULL };
 
 void print_logheader(sparkey_logheader *header) {
   printf("Log file version %d.%d\n", header->major_version,
@@ -59,7 +59,7 @@ static sparkey_returncode logheader_version0(sparkey_logheader *header, FILE *fp
   if (header->num_deletes > header->data_end) {
     return SPARKEY_LOG_HEADER_CORRUPT;
   }
-  if (header->compression_type > SPARKEY_COMPRESSION_SNAPPY) {
+  if (header->compression_type > SPARKEY_COMPRESSION_ZSTD) {
     return SPARKEY_LOG_HEADER_CORRUPT;
   }
   return SPARKEY_SUCCESS;

--- a/src/logreader.c
+++ b/src/logreader.c
@@ -21,8 +21,6 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 
-#include <snappy-c.h>
-
 #include "sparkey.h"
 #include "sparkey-internal.h"
 #include "logheader.h"
@@ -223,22 +221,17 @@ static sparkey_returncode seekblock(sparkey_logiter *iter, sparkey_logreader *lo
   }
   if (log->header.compression_type == SPARKEY_COMPRESSION_SNAPPY) {
     uint64_t pos = position;
-    // TODO: assert that size_t >= uint64_t
-    size_t compressed_size = read_vlq(log->data, &pos);
+    // TODO: assert that we're not reading > uint32_t
+    uint32_t compressed_size = read_vlq(log->data, &pos);
     uint64_t next_pos = pos + compressed_size;
-    const char *input = (char *) &log->data[pos];
+    uint32_t uncompressed_size = log->header.compression_block_size;
 
-    size_t uncompressed_size = log->header.compression_block_size;
-    snappy_status status = snappy_uncompress(input, compressed_size, (char *) iter->compression_buf, &uncompressed_size);
-    switch (status) {
-    case SNAPPY_OK: break;
-    case SNAPPY_INVALID_INPUT:
-      return SPARKEY_INTERNAL_ERROR;
-    case SNAPPY_BUFFER_TOO_SMALL:
-      return SPARKEY_INTERNAL_ERROR;
-    default:
-      return SPARKEY_INTERNAL_ERROR;
+    sparkey_returncode ret = sparkey_compressors[log->header.compression_type].decompress(
+      &log->data[pos], compressed_size, iter->compression_buf, &uncompressed_size);
+    if (ret != SPARKEY_SUCCESS) {
+      return ret;
     }
+
     iter->block_position = position;
     iter->next_block_position = next_pos;
     iter->block_len = uncompressed_size;

--- a/src/main.c
+++ b/src/main.c
@@ -28,8 +28,7 @@
 
 #define MINIMUM_CAPACITY (1<<8)
 #define MAXIMUM_CAPACITY (1<<28)
-#define SNAPPY_DEFAULT_BLOCKSIZE (1<<12)
-#define ZSTD_DEFAULT_BLOCKSIZE (1<<14)
+#define COMP_DEFAULT_BLOCKSIZE (1<<12)
 #define COMP_MAX_BLOCKSIZE (1<<30)
 #define COMP_MIN_BLOCKSIZE (1<<4)
 
@@ -71,8 +70,8 @@ static void usage_createlog() {
   fprintf(stderr, "  Create a new empty log file.\n");
   fprintf(stderr, "Options:\n");
   fprintf(stderr, "  -c <none|snappy|zstd>  Compression algorithm [default: none]\n");
-  fprintf(stderr, "  -b <n>                 Compression blocksize [default: snappy %d, zstd %d]\n",
-    SNAPPY_DEFAULT_BLOCKSIZE, ZSTD_DEFAULT_BLOCKSIZE);
+  fprintf(stderr, "  -b <n>                 Compression blocksize [default: %d]\n",
+    COMP_DEFAULT_BLOCKSIZE);
   fprintf(stderr, "                    [min: %d, max: %d]\n",
     COMP_MIN_BLOCKSIZE, COMP_MAX_BLOCKSIZE);
 }
@@ -288,7 +287,7 @@ int main(int argc, char * const *argv) {
     opterr = 0;
     optind = 2;
     int opt_char;
-    int block_size = 0;
+    int block_size = COMP_DEFAULT_BLOCKSIZE;
     sparkey_compression_type compression_type = SPARKEY_COMPRESSION_NONE;
     while ((opt_char = getopt (argc, argv, "b:c:")) != -1) {
       switch (opt_char) {
@@ -308,14 +307,8 @@ int main(int argc, char * const *argv) {
           compression_type = SPARKEY_COMPRESSION_NONE;
         } else if (strcmp(optarg, "snappy") == 0) {
           compression_type = SPARKEY_COMPRESSION_SNAPPY;
-          if (block_size == 0) {
-            block_size = SNAPPY_DEFAULT_BLOCKSIZE;
-          }
         } else if (strcmp(optarg, "zstd") == 0) {
           compression_type = SPARKEY_COMPRESSION_ZSTD;
-          if (block_size == 0) {
-            block_size = ZSTD_DEFAULT_BLOCKSIZE;
-          }
         } else {
           fprintf(stderr, "Invalid compression type: '%s'\n", optarg);
           return 1;

--- a/src/sparkey-internal.h
+++ b/src/sparkey-internal.h
@@ -94,5 +94,6 @@ struct sparkey_compressor {
 };
 
 extern struct sparkey_compressor sparkey_compressors[3];
+int sparkey_uses_compressor(sparkey_compression_type t);
 
 #endif

--- a/src/sparkey-internal.h
+++ b/src/sparkey-internal.h
@@ -93,4 +93,6 @@ struct sparkey_compressor {
   sparkey_returncode (*compress)(uint8_t *input, uint32_t uncompressed_size, uint8_t *output, uint32_t *compressed_size);
 };
 
+extern struct sparkey_compressor sparkey_compressors[3];
+
 #endif

--- a/src/sparkey-internal.h
+++ b/src/sparkey-internal.h
@@ -87,4 +87,10 @@ struct sparkey_hashreader {
 sparkey_returncode sparkey_logreader_open_noalloc(sparkey_logreader *log, const char *filename);
 void sparkey_logreader_close_nodealloc(sparkey_logreader *log);
 
+struct sparkey_compressor {
+  uint32_t (*max_compressed_size)(uint32_t block_size);
+  sparkey_returncode (*decompress)(uint8_t *input, uint32_t compressed_size, uint8_t *output, uint32_t *uncompressed_size);
+  sparkey_returncode (*compress)(uint8_t *input, uint32_t uncompressed_size, uint8_t *output, uint32_t *compressed_size);
+};
+
 #endif

--- a/src/sparkey.h
+++ b/src/sparkey.h
@@ -266,7 +266,8 @@ typedef struct sparkey_logwriter sparkey_logwriter;
 
 typedef enum {
   SPARKEY_COMPRESSION_NONE,
-  SPARKEY_COMPRESSION_SNAPPY
+  SPARKEY_COMPRESSION_SNAPPY,
+  SPARKEY_COMPRESSION_ZSTD
 } sparkey_compression_type;
 
 typedef enum {

--- a/src/testsystem.c
+++ b/src/testsystem.c
@@ -237,17 +237,19 @@ int main() {
   verify(SPARKEY_COMPRESSION_NONE, 0, 0, 0, 0, 100);
   verify(SPARKEY_COMPRESSION_NONE, 0, 0, 100, 10, 5);
 
-  verify(SPARKEY_COMPRESSION_SNAPPY, 10, 0, 100, 0, 0);
-  verify(SPARKEY_COMPRESSION_SNAPPY, 20, 0, 100, 0, 0);
-  verify(SPARKEY_COMPRESSION_SNAPPY, 100, 0, 100, 0, 0);
-  verify(SPARKEY_COMPRESSION_SNAPPY, 100, 0, 1000, 0, 0);
-  verify(SPARKEY_COMPRESSION_SNAPPY, 1000, 0, 1000, 0, 0);
+  for (sparkey_compression_type t = SPARKEY_COMPRESSION_SNAPPY; t <= SPARKEY_COMPRESSION_ZSTD; t++) {
+    verify(t, 10, 0, 100, 0, 0);
+    verify(t, 20, 0, 100, 0, 0);
+    verify(t, 100, 0, 100, 0, 0);
+    verify(t, 100, 0, 1000, 0, 0);
+    verify(t, 1000, 0, 1000, 0, 0);
 
-  verify(SPARKEY_COMPRESSION_SNAPPY, 100, 0, 1000, 100, 0);
-  verify(SPARKEY_COMPRESSION_SNAPPY, 100, 0, 1000, 100, 50);
+    verify(t, 100, 0, 1000, 100, 0);
+    verify(t, 100, 0, 1000, 100, 50);
 
-  verify(SPARKEY_COMPRESSION_SNAPPY, 100, 4, 1000, 0, 0);
-  verify(SPARKEY_COMPRESSION_SNAPPY, 100, 8, 1000, 0, 0);
+    verify(t, 100, 4, 1000, 0, 0);
+    verify(t, 100, 8, 1000, 0, 0);
+  }
 
   printf("Success!\n");
 }


### PR DESCRIPTION
[Zstd](https://github.com/facebook/zstd) is a fast compressor with a better compression ratio than Snappy. It's been gaining support pretty quickly! This PR adds a "compressor" abstraction to Sparkey, and adds Zstd as an option.

Tests and benchmarks seem to indicate this works well. Data is about 60% of the size of Snappy data, but lookups are between 30-70% slower on 4K blocks—which makes sense, Zstd usually targets larger block sizes. For my use case, that's a very worthwhile tradeoff, I'm limited on I/O much more than CPU.

I also have a Java port: https://github.com/vasi/sparkey-java/tree/zstd

It might be annoying to some folks that this now requires Zstd. We could make it optional, but then someone's build of Sparkey may or may not be able to open a given file, so it's a trade-off. Happy to defer to you on this.