### PR TITLE
Close the log file resources when sparkey_hash_open validation fails

### DIFF
--- a/src/hashreader.c
+++ b/src/hashreader.c
@@ -102,10 +102,11 @@ void sparkey_hash_close(sparkey_hashreader **reader_ref) {
     return;
   }
 
+  sparkey_logreader_close_nodealloc(&reader->log);
+
   if (reader->open_status != MAGIC_VALUE_HASHREADER) {
     return;
   }
-  sparkey_logreader_close_nodealloc(&reader->log);
 
   reader->open_status = 0;
   if (reader->data != NULL) {


### PR DESCRIPTION
fixes #46 

Make sure `munmap` and `close` are called when the hash and log have been opened but failed the validations done in `sparkey_hash_open`.

Super tiny change - I haven't verified in every caller yet that it's appropriate to do this in `sparkey_hash_close`, but here's my diff. It _does_ fix my repro program. I have a test in mind that I want to add.